### PR TITLE
update pixiv url format

### DIFF
--- a/lib/fumimi.rb
+++ b/lib/fumimi.rb
@@ -96,7 +96,7 @@ module Fumimi::Events
 
   respond(:pixiv_id, /pixiv #[0-9]+/i) do |event, text|
     id = text[/[0-9]+/]
-    event << "https://www.pixiv.net/en/artworks/#{id}"
+    event << "https://www.pixiv.net/artworks/#{id}"
   end
 
   respond(:pool_id, /pool #[0-9]+/i) do |event, text|

--- a/lib/fumimi.rb
+++ b/lib/fumimi.rb
@@ -96,7 +96,7 @@ module Fumimi::Events
 
   respond(:pixiv_id, /pixiv #[0-9]+/i) do |event, text|
     id = text[/[0-9]+/]
-    event << "https://www.pixiv.net/member_illust.php?mode=medium&illust_id=#{id}"
+    event << "https://www.pixiv.net/en/artworks/#{id}"
   end
 
   respond(:pool_id, /pool #[0-9]+/i) do |event, text|


### PR DESCRIPTION
the format for pixiv's url has changed to be more modern. i dont know when, but someone in the discord brought it up and honestly the whole member_ilust.php? looked ugly. This is more modern and sleek.